### PR TITLE
Filter repeating time entries on loading the data

### DIFF
--- a/EccRed.py
+++ b/EccRed.py
@@ -73,6 +73,10 @@ print("# time:", tcol+1, "   distance:", dcol+1, "   r0:", dcoordcol+1)
 # load data
 data = np.loadtxt(args.file, comments=['#', '"', '$'])
 
+# filter repeating time entries, e.g., after a restarts
+_, mask = np.unique(data[:,tcol], return_index=True)
+data = data[mask]
+
 # get time data
 tdata = data[:,tcol]
 

--- a/EccRed_noForceBal.py
+++ b/EccRed_noForceBal.py
@@ -73,6 +73,10 @@ print("# time:", tcol+1, "   distance:", dcol+1, "   r0:", dcoordcol+1)
 # load data
 data = np.loadtxt(args.file, comments=['#', '"', '$'])
 
+# filter repeating time entries, e.g., after a restarts
+_, mask = np.unique(data[:,tcol], return_index=True)
+data = data[mask]
+
 # get time data
 tdata = data[:,tcol]
 


### PR DESCRIPTION
After BAM restarts, it will write duplicate distance entries which need to be removed.